### PR TITLE
Replace Species.from_string() with Species.from_str()

### DIFF
--- a/pymatgen/analysis/alloys/core.py
+++ b/pymatgen/analysis/alloys/core.py
@@ -467,13 +467,13 @@ class AlloyPair(MSONable):
 
         if (anions_a or cations_a) and (anions_b or cations_b):
 
-            ions_a = [Species.from_string(sp) for sp in anions_a] + [
-                Species.from_string(sp) for sp in cations_a
+            ions_a = [Species.from_str(sp) for sp in anions_a] + [
+                Species.from_str(sp) for sp in cations_a
             ]
             elements_a = [str(sp.element) for sp in ions_a]
 
-            ions_b = [Species.from_string(sp) for sp in anions_b] + [
-                Species.from_string(sp) for sp in cations_b
+            ions_b = [Species.from_str(sp) for sp in anions_b] + [
+                Species.from_str(sp) for sp in cations_b
             ]
             elements_b = [str(sp.element) for sp in ions_b]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pymatgen>=2022.0.16
+pymatgen>=2023.7.17
 shapely

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@
 # and distributed under the terms of the Modified BSD License.
 # pymatgen-analysis-alloys is Copyright (c) Rachel Woods-Robinson, Matthew Horton
 
-from setuptools import setup, find_namespace_packages
-
 import os
+
+from setuptools import find_namespace_packages, setup
 
 SETUP_PTH = os.path.dirname(os.path.abspath(__file__))
 
@@ -18,7 +18,7 @@ setup(
     name="pymatgen-analysis-alloys",
     packages=find_namespace_packages(include=["pymatgen.analysis.*"]),
     version="0.0.6",
-    install_requires=["pymatgen>=2022.0.3", "shapely>=1.8.2"],
+    install_requires=["pymatgen>=2023.7.17", "shapely>=1.8.2"],
     extras_require={},
     package_data={
         "pymatgen.analysis.alloys": ["*.yaml", "*.json", "*.csv"],


### PR DESCRIPTION
pymatgen's `Species` class no longer has a `from_string` method. I am guessing this was renamed at some point to be `from_str`